### PR TITLE
Add hover effect with focus overlay for Pokémon cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,5 +15,6 @@
             <section id="card-Container">
             </section>
         </div>
+        <div id ="overlay"></div>
     </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -25,12 +25,20 @@ let currentHoverCard = null;
 
 
 cardContainer.addEventListener('mouseenter',function(event){
-
     const card = event.target.closest('.individualCard');
     if(card&& cardContainer.contains(card)){
         overlay.style.display = 'block';
         card.classList.add('card-on-hover');
         card.style.zIndex = 101;
         currentHoverCard = card;
+    }
+    },{capture:true});
+
+cardContainer.addEventListener('mouseleave',function(event){
+    const card = event.target.closest('.individualCard');
+    if(card&& card == currentHoverCard){
+        overlay.style.display = 'none';
+        card.classList.remove('card-on-hover');
+        card.style.zIndex = '';
     }
     },{capture:true});

--- a/script.js
+++ b/script.js
@@ -19,3 +19,18 @@ for(let pokemon of pokemonDataset){
 
 
 }
+const cardContainer = document.querySelector("#card-Container");
+const overlay = document.querySelector("#overlay");
+let currentHoverCard = null;
+
+
+cardContainer.addEventListener('mouseenter',function(event){
+
+    const card = event.target.closest('.individualCard');
+    if(card&& cardContainer.contains(card)){
+        overlay.style.display = 'block';
+        card.classList.add('card-on-hover');
+        card.style.zIndex = 101;
+        currentHoverCard = card;
+    }
+    },{capture:true});

--- a/style.css
+++ b/style.css
@@ -71,3 +71,12 @@ body{
 h1{
     font-size:2.5em;
 }
+#overlay{
+    position:fixed;
+    top:0;
+    left:0;
+    background-color:blue;
+    height:100vh;
+    width:100vw;
+
+}

--- a/style.css
+++ b/style.css
@@ -87,8 +87,17 @@ h1{
     */
 
 }
+.card-on-hover {
+  transform: scale(1.15) rotateZ(-1deg);
+  border: 2px solid gold;
+  background: linear-gradient(135deg, #fffacd, #ffffe0);
+  box-shadow: 0 10px 25px rgba(255, 255, 100, 0.6), 0 0 15px rgba(255, 255, 160, 0.4);
+  border-radius: 15px;
 
-.card-on-hover{
-    transform:scale(1.5);
-    background-color:yellow;
+  transition:
+    transform 0.4s cubic-bezier(0.22, 1, 0.36, 1),
+    border 0.3s ease-in-out,
+    background 0.4s ease-in-out,
+    box-shadow 0.4s ease-in-out,
+    border-radius 0.4s ease;
 }

--- a/style.css
+++ b/style.css
@@ -80,5 +80,10 @@ h1{
     width:100vw;
     display:none; /*hiding it*/
     pointer-events:none; /* allows interaction with elements below */
+    z-index: 100;
+    /*z-index is a CSS property that controls the stacking order of elements on a webpage —
+    in other words, what appears in front and what appears behind when elements overlap.
+    higher the z-index the element would appear on top; works on position(fixed,realtive,absoulute) elements
+    */
 
 }

--- a/style.css
+++ b/style.css
@@ -87,3 +87,8 @@ h1{
     */
 
 }
+
+.card-on-hover{
+    transform:scale(1.5);
+    background-color:yellow;
+}

--- a/style.css
+++ b/style.css
@@ -88,12 +88,11 @@ h1{
 
 }
 .card-on-hover {
-  transform: scale(1.15) rotateZ(-1deg);
+  transform: scale(1.15);
   border: 2px solid gold;
   background: linear-gradient(135deg, #fffacd, #ffffe0);
   box-shadow: 0 10px 25px rgba(255, 255, 100, 0.6), 0 0 15px rgba(255, 255, 160, 0.4);
   border-radius: 15px;
-
   transition:
     transform 0.4s cubic-bezier(0.22, 1, 0.36, 1),
     border 0.3s ease-in-out,

--- a/style.css
+++ b/style.css
@@ -78,5 +78,7 @@ h1{
     background-color:blue;
     height:100vh;
     width:100vw;
+    display:none; /*hiding it*/
+    pointer-events:none; /* allows interaction with elements below */
 
 }

--- a/style.css
+++ b/style.css
@@ -99,4 +99,6 @@ h1{
     background 0.4s ease-in-out,
     box-shadow 0.4s ease-in-out,
     border-radius 0.4s ease;
+    cursor: pointer;
+
 }

--- a/style.css
+++ b/style.css
@@ -75,7 +75,7 @@ h1{
     position:fixed;
     top:0;
     left:0;
-    background-color:blue;
+    background-color:rgba(0, 0, 0, 0.6);
     height:100vh;
     width:100vw;
     display:none; /*hiding it*/


### PR DESCRIPTION
- Added a hover effect on Pokémon cards using a `card-on-hover` class
- Introduced a dimmed background overlay (`#overlay`) that appears on hover to emphasize focus on a selected card
- Applied smooth transitions (scale, shadow, border) for a richer visual experience
- Ensured overlay is non-interactive with `pointer-events: none` so cards remain clickable